### PR TITLE
Remove unnecessary dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,7 @@
       "version": "1.0.0",
       "devDependencies": {
         "esbuild": "^0.14.36",
-        "highlight.js": "11.4.0",
-        "marked": "4.0.12",
-        "reveal.js": "4.3.0"
+        "reveal.js": "^4.3.0"
       }
     },
     "node_modules/esbuild": {
@@ -369,27 +367,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/highlight.js": {
-      "version": "11.4.0",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.4.0.tgz",
-      "integrity": "sha512-nawlpCBCSASs7EdvZOYOYVkJpGmAOKMYZgZtUqSRqodZE0GRVcFKwo1RcpeOemqh9hyttTdd5wDBwHkuSyUfnA==",
-      "dev": true,
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/marked": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
-      "integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==",
-      "dev": true,
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/reveal.js": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/reveal.js/-/reveal.js-4.3.0.tgz",
@@ -568,18 +545,6 @@
       "integrity": "sha512-fBB4WlDqV1m18EF/aheGYQkQZHfPHiHJSBYzXIo8yKehek+0BtBwo/4PNwKGJ5T0YK0oc8pBKjgwPbzSrPLb+Q==",
       "dev": true,
       "optional": true
-    },
-    "highlight.js": {
-      "version": "11.4.0",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.4.0.tgz",
-      "integrity": "sha512-nawlpCBCSASs7EdvZOYOYVkJpGmAOKMYZgZtUqSRqodZE0GRVcFKwo1RcpeOemqh9hyttTdd5wDBwHkuSyUfnA==",
-      "dev": true
-    },
-    "marked": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
-      "integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==",
-      "dev": true
     },
     "reveal.js": {
       "version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -11,8 +11,6 @@
   },
   "devDependencies": {
     "esbuild": "^0.14.36",
-    "highlight.js": "^11.4.0",
-    "marked": "^4.0.12",
     "reveal.js": "^4.3.0"
   }
 }


### PR DESCRIPTION
reveal.js already bundles its plugins and the respective dependencies in-tree. It is not necessary to include them additionally.