### PR TITLE
Improve blockquote style

### DIFF
--- a/src/styles/zuehlke.css
+++ b/src/styles/zuehlke.css
@@ -294,6 +294,45 @@ body {
 }
 
 /*********************************************
+ * QUOTES
+ *********************************************/
+.reveal blockquote {
+    display: block;
+    position: relative;
+    width: 70%;
+    max-width: max-content;
+    margin: 20px auto;
+    padding: 5px;
+    font-style: italic;
+    background: rgba(255, 255, 255, 0.05);
+}
+
+.reveal blockquote:before,
+.reveal blockquote:after {
+    font-size: 4em;
+    font-style: normal;
+    color: var(--zuehlke-purple);
+    opacity: .3;
+    position: absolute;
+}
+
+.reveal blockquote:before {
+    content: '“';
+    top: -.2em;
+    left: -.5em;
+}
+
+.reveal blockquote:after {
+    content: '”';
+    right: -.5em;
+    bottom: -.8em;
+}
+
+.reveal q {
+    font-style: italic;
+}
+
+/*********************************************
  * OTHER
  *********************************************/
 .reveal p {
@@ -329,26 +368,6 @@ body {
 
 .reveal dd {
     margin-left: 40px;
-}
-
-.reveal blockquote {
-    display: block;
-    position: relative;
-    width: 70%;
-    margin: 20px auto;
-    padding: 5px;
-    font-style: italic;
-    background: rgba(255, 255, 255, 0.05);
-    box-shadow: 0 0 2px rgba(0, 0, 0, 0.2);
-}
-
-.reveal blockquote p:first-child,
-.reveal blockquote p:last-child {
-    display: inline-block;
-}
-
-.reveal q {
-    font-style: italic;
 }
 
 .reveal pre {


### PR DESCRIPTION
Adds big semi-transparent quotations in Zühlke purple to blockquotes, like this:

![image](https://user-images.githubusercontent.com/8446762/198557218-e118fd0a-43d1-48ee-9f63-98f21d813b20.png)
